### PR TITLE
Simple refactor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ cp .env.template .env
 
 2.	Edit the .env file to add your specific API details. Open .env in a text editor and fill in the required values:
 ```bash
-API_URL=https://lamapi.hel.sintef.cloud/lookup/entity-retrieval
-API_TOKEN=your_api_token  # Replace with your actual API token
+RETRIEVER_ENDPOINT=https://lamapi.hel.sintef.cloud/lookup/entity-retrieval
+RETRIEVER_TOKEN=your_api_token  # Replace with your actual API token
 ```
-The .env file will be used to securely store your API credentials and other sensitive configuration data, so make sure it is not committed to version control.
+The .env file will be used to securely store your Retriever credentials and other sensitive configuration data, so make sure it is not committed to version control.
 
-3.	Verify the .env file by checking that API_URL and API_TOKEN are correctly set, as these values will be automatically loaded by lion_linker when it runs.
+3.	Verify the .env file by checking that RETRIEVER_ENDPOINT and RETRIEVER_TOKEN are correctly set, as these values will be automatically loaded by lion_linker when it runs.
 
 ## Usage
 
@@ -72,56 +72,67 @@ The .env file will be used to securely store your API credentials and other sens
 
 ```python
 import os
+import subprocess
+
 from dotenv import load_dotenv
+
 from lion_linker.lion_linker import LionLinker
+from lion_linker.retrievers import LamapiClient
 
 # Load environment variables from the .env file
 load_dotenv()
 
 # Define necessary file paths and parameters
-input_csv = 'tests/data/film.csv'
-prompt_file = 'prompt_template.txt'
-model_name = 'llama3.2:1b'  # Use the correct model name
-output_csv = 'output_test.csv'
-batch_size = 10  # Set batch size for processing
-api_limit = 20  # Maximum number of results from the API per request
+input_csv = "tests/data/film.csv"
+prompt_file_path = "lion_linker/prompt/prompt_template.txt"
+model_name = "gemma2:2b"  # Use the correct model name
+output_csv = "output_test.csv"
+chunk_size = 16  # How many rows to process
+num_candidates = 20  # Maximum number of candidates from the Retriever per mention
 format_candidates = True  # Format candidates as in TableLlama prompt
 table_ctx_size = 1
 
 # Load API parameters from environment variables
-api_url = os.getenv('API_URL')
-api_token = os.getenv('API_TOKEN')
+retriever_endpoint = os.getenv("RETRIEVER_ENDPOINT")
+retriever_token = os.getenv("RETRIEVER_TOKEN")
 
 # Additional parameters as per the latest LionLinker version
 mention_columns = ["title"]  # Columns to link entities from
 compact_candidates = True  # Whether to compact candidates list
-model_api_provider = 'ollama'  # Optional model API provider
-ollama_host="http://localhost:11434" # Default Ollama host if not specified it will use the Default Ollama host anyway
+model_api_provider = "ollama"  # Optional model API provider
+ollama_host = "http://localhost:11434"  # Default Ollama host if not specified it will use the Default Ollama host anyway
 model_api_key = None  # Optional model API key if required
 gt_columns = []  # Specify any ground truth columns to exclude for testing
+
+# Initialize the retriever instance
+retriever = LamapiClient(retriever_endpoint, retriever_token, num_candidates=num_candidates)
 
 # Initialize the LionLinker instance
 lion_linker = LionLinker(
     input_csv=input_csv,
-    prompt_file=prompt_file,
     model_name=model_name,
-    api_url=api_url,
-    api_token=api_token,
+    retriever=retriever,
     output_csv=output_csv,
-    batch_size=batch_size,
+    prompt_file_path=prompt_file_path,
+    chunk_size=chunk_size,
     mention_columns=mention_columns,
-    api_limit=api_limit,
     compact_candidates=compact_candidates,
     model_api_provider=model_api_provider,
     ollama_host=ollama_host,
     model_api_key=model_api_key,
     gt_columns=gt_columns,
     table_ctx_size=table_ctx_size,
-    format_candidates=format_candidates
+    format_candidates=format_candidates,
 )
+
+# Start the Ollama server as a background process
+process = subprocess.Popen(["ollama", "serve"])
 
 # Run the entity linking
 await lion_linker.run()
+
+# Stop the Ollama server
+process.terminate()
 ```
 
 ### CLI Example
@@ -129,11 +140,11 @@ await lion_linker.run()
 ```bash
 python3 -m lion_linker.cli tests/data/film.csv output_test.csv \
   --ollama_host http://localhost:11434 \
-  --prompt_file lion_linker/prompt/optimized_prompt_template.txt \
+  --prompt_file_path lion_linker/prompt/optimized_prompt_template.txt \
   --model gemma2:2b \
-  --batch_size 10 \
+  --chunk_size 16 \
   --mention_columns title \
-  --api_limit 20 \
+  --num_candidates 10 \
   --table_ctx_size 2 \
   --format_candidates
 ```
@@ -143,11 +154,11 @@ python3 -m lion_linker.cli tests/data/film.csv output_test.csv \
 - `input_csv`: Path to your input CSV file.
 - `output_csv`: Path where the output file will be saved.
 - `ollama_host`: The host where the Ollama service is running.
-- `--prompt-file`: Path to a file containing a custom prompt template.
+- `--prompt_file_path`: Path to a file containing a custom prompt template.
 - `--model`: The LLM model to use for entity linking.
-- `--batch-size`: Defines how many rows to process at once.
+- `--chunk_size`: Defines how many rows to process at once.
 - `--mention_columns`: Columns in the CSV that contain entity mentions.
-- `--api-limit`: Maximum number of results returned by the API per batch.
+- `--num_candidates`: Maximum number of candidates returned by the API per mention.
 
 ## Running Tests
 

--- a/lion_linker/__init__.py
+++ b/lion_linker/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/lion_linker/cli.py
+++ b/lion_linker/cli.py
@@ -28,7 +28,9 @@ async def main():
     parser.add_argument(
         "--retriever_token", default=os.getenv("RETRIEVER_TOKEN"), help="Optional retriever token."
     )
-    parser.add_argument("--prompt_file", required=True, help="File containing prompt template.")
+    parser.add_argument(
+        "--prompt_file_path", required=True, help="File containing prompt template."
+    )
     parser.add_argument("--model", required=True, help="LLM model name.")
     parser.add_argument("--chunk_size", type=int, default=64, help="Chunk size for processing.")
     parser.add_argument(
@@ -37,7 +39,9 @@ async def main():
         required=True,
         help="List of columns containing entity mentions.",
     )
-    parser.add_argument("--api_limit", type=int, default=20, help="Limit for API calls per batch.")
+    parser.add_argument(
+        "--num_candidates", type=int, default=20, help="Limit for API calls per batch."
+    )
     parser.add_argument(
         "--compact_candidates", action="store_true", help="Whether to compact candidates."
     )
@@ -66,18 +70,21 @@ async def main():
 
     args = parser.parse_args()
 
-    retriever = LamapiClient(endpoint=args.retriever_endpoint, token=args.retriever_token)
+    retriever = LamapiClient(
+        endpoint=args.retriever_endpoint,
+        token=args.retriever_token,
+        num_candidates=args.num_candidates,
+    )
 
     # Initialize the LionLinker instance with the parsed arguments
     lion_linker = LionLinker(
         input_csv=args.input_csv,
-        prompt_file=args.prompt_file,
+        prompt_file_path=args.prompt_file_path,
         model_name=args.model,
         retriever=retriever,
         output_csv=args.output_csv,
         chunk_size=args.chunk_size,
         mention_columns=args.mention_columns,
-        api_limit=args.api_limit,
         compact_candidates=args.compact_candidates,
         model_api_provider=args.model_api_provider,
         ollama_host=args.ollama_host,

--- a/lion_linker/cli.py
+++ b/lion_linker/cli.py
@@ -7,6 +7,7 @@ import traceback
 from dotenv import load_dotenv
 
 from lion_linker.lion_linker import LionLinker
+from lion_linker.retrievers import LamapiClient
 
 # Load environment variables from .env file if present
 load_dotenv()
@@ -20,12 +21,16 @@ async def main():
     parser.add_argument("input_csv", help="Path to the input CSV file.")
     parser.add_argument("output_csv", help="Path to the output CSV file.")
     parser.add_argument(
-        "--api_url", default=os.getenv("API_URL"), help="Entity retrieval API URL."
+        "--retriever_endpoint",
+        default=os.getenv("RETRIEVER_ENDPOINT"),
+        help="Entity retrieval URL.",
     )
-    parser.add_argument("--api_token", default=os.getenv("API_TOKEN"), help="Optional API token.")
+    parser.add_argument(
+        "--retriever_token", default=os.getenv("RETRIEVER_TOKEN"), help="Optional retriever token."
+    )
     parser.add_argument("--prompt_file", required=True, help="File containing prompt template.")
     parser.add_argument("--model", required=True, help="LLM model name.")
-    parser.add_argument("--batch_size", type=int, default=100, help="Batch size for processing.")
+    parser.add_argument("--chunk_size", type=int, default=64, help="Chunk size for processing.")
     parser.add_argument(
         "--mention_columns",
         nargs="*",
@@ -61,15 +66,16 @@ async def main():
 
     args = parser.parse_args()
 
+    retriever = LamapiClient(endpoint=args.retriever_endpoint, token=args.retriever_token)
+
     # Initialize the LionLinker instance with the parsed arguments
     lion_linker = LionLinker(
         input_csv=args.input_csv,
         prompt_file=args.prompt_file,
         model_name=args.model,
-        api_url=args.api_url,
-        api_token=args.api_token,
+        retriever=retriever,
         output_csv=args.output_csv,
-        batch_size=args.batch_size,
+        chunk_size=args.chunk_size,
         mention_columns=args.mention_columns,
         api_limit=args.api_limit,
         compact_candidates=args.compact_candidates,

--- a/lion_linker/lion_linker.py
+++ b/lion_linker/lion_linker.py
@@ -1,13 +1,17 @@
 import logging
 import os
 import re
+from pathlib import Path
 
 import pandas as pd
 from tqdm.asyncio import tqdm
 
-from lion_linker.core import APIClient, LLMInteraction
+from lion_linker import PROJECT_ROOT
+from lion_linker.core import LLMInteraction
 from lion_linker.prompt.generator import PromptGenerator
-from lion_linker.utils import parse_response
+from lion_linker.retrievers import RetrieverClient
+
+DEFAULT_PROMPT_FILE_PATH = os.path.join(PROJECT_ROOT, "prompt", "prompt_template.txt")
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -16,16 +20,13 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 class LionLinker:
     def __init__(
         self,
-        input_csv,
-        prompt_file,
-        model_name,
-        api_url,
-        api_token,
-        output_csv,
-        kg="wikidata",
-        batch_size=1000,
+        input_csv: str | Path,
+        model_name: str,
+        retriever: RetrieverClient,
+        output_csv: str | None = None,
+        prompt_file_path=DEFAULT_PROMPT_FILE_PATH,
+        chunk_size=64,
         mention_columns=None,
-        api_limit=10,
         compact_candidates=True,
         model_api_provider="ollama",
         ollama_host=None,
@@ -34,15 +35,16 @@ class LionLinker:
         table_ctx_size: int = 1,
         format_candidates=True,
     ):
+        if not os.path.exists(input_csv) or os.path.splitext(input_csv)[1] != ".csv":
+            raise ValueError("Input CSV file does not exist or is not a CSV file.")
         self.input_csv = input_csv
-        self.prompt_file = prompt_file
+        self.prompt_file_path = prompt_file_path
         self.model_name = model_name
-        self.api_url = api_url
-        self.api_token = api_token
-        self.api_limit = api_limit
+        self.retriever = retriever
         self.output_csv = output_csv
-        self.kg = kg
-        self.batch_size = batch_size
+        if not self.output_csv:
+            self.output_csv = os.path.splitext(input_csv)[0] + "_output.csv"
+        self.chunk_size = chunk_size
         self.mention_columns = mention_columns or []  # List of columns containing entity mentions
         self.compact_candidates = compact_candidates
         self.model_api_provider = model_api_provider
@@ -56,32 +58,20 @@ class LionLinker:
                 "Table context size must be at least 0. "
                 f"Got table context size: {self.table_ctx_size}"
             )
-        if self.batch_size < 1:
-            raise ValueError(f"Batch size must be at least 1. Got batch size: {self.batch_size}")
-        if self.batch_size < 2 * self.table_ctx_size + 1:
+        if self.chunk_size < 1:
+            raise ValueError(f"Chuck size must be at least 1. Got batch size: {self.chunk_size}")
+        if self.chunk_size < 2 * self.table_ctx_size + 1:
             raise ValueError(
                 "Batch size must be at least 2 * table context size + 1. "
-                f"Got batch size: {self.batch_size}, table context size: {self.table_ctx_size}"
+                f"Got batch size: {self.chunk_size}, table context size: {self.table_ctx_size}"
             )
 
         logging.info("Initializing components...")
-        # Initialize components
-        self.api_client = APIClient(
-            self.api_url,
-            token=self.api_token,
-            kg=self.kg,
-            limit=self.api_limit,
-            parse_response_func=parse_response,
-        )
-        self.prompt_generator = PromptGenerator(self.prompt_file)
+        self.prompt_generator = PromptGenerator(self.prompt_file_path)
+
         logging.info(f"Model API provider is: {self.model_api_provider}")
         self.llm_interaction = LLMInteraction(
             self.model_name, self.model_api_provider, self.ollama_host, self.model_api_key
-        )
-
-        # Initialize the output CSV with headers
-        pd.DataFrame(columns=["Identifier", "LLM Answer", "Extracted Identifier"]).to_csv(
-            self.output_csv, index=False
         )
 
         logging.info("Setup completed.")
@@ -118,7 +108,7 @@ class LionLinker:
             mentions.extend(chunk[column].dropna().unique())
 
         # Run the async fetch candidates function
-        mentions_to_candidates = await self.api_client.fetch_multiple_entities(mentions)
+        mentions_to_candidates = await self.retriever.fetch_multiple_entities(mentions)
         results = []
         for loc_idx, (id_row, row) in enumerate(chunk.iterrows()):
             table_view = chunk.iloc[
@@ -144,7 +134,7 @@ class LionLinker:
                 base_filename = os.path.splitext(os.path.basename(self.input_csv))[0]
 
                 # Creating identifier for the row and column
-                identifier = f"{base_filename}-{id_row}-{id_col}"
+                f"{base_filename}-{id_row}-{id_col}"
 
                 # Call LLM for each prompt individually
                 response = self.llm_interaction.chat(prompt)
@@ -154,11 +144,9 @@ class LionLinker:
 
                 results.append(
                     {
-                        "Identifier": identifier,
-                        "LLM Answer": response.replace(
-                            "\n", ""
-                        ).strip(),  # Replace newlines with empty string
-                        "Extracted Identifier": extracted_identifier,
+                        "id_row": id_row,
+                        f"{column}_llm_answer": " ".join(response.split()),
+                        f"{column}_qid": extracted_identifier,
                     }
                 )
 
@@ -207,7 +195,7 @@ class LionLinker:
         total_rows = 0
         chunks_to_sample = 5  # Number of chunks to sample
 
-        with pd.read_csv(self.input_csv, chunksize=self.batch_size) as reader:
+        with pd.read_csv(self.input_csv, chunksize=self.chunk_size) as reader:
             for i, chunk in enumerate(reader):
                 if i >= chunks_to_sample:
                     break
@@ -231,7 +219,7 @@ class LionLinker:
 
     async def compute_table_summary(self):
         # Read the first batch from the CSV
-        first_batch = pd.read_csv(self.input_csv, chunksize=self.batch_size)
+        first_batch = pd.read_csv(self.input_csv, chunksize=self.chunk_size)
         first_chunk = next(first_batch, None)
 
         if first_chunk is not None:
@@ -240,13 +228,13 @@ class LionLinker:
             self.table_summary = self.generate_table_summary(sample_data)
         else:
             raise ValueError("Not enough data to compute table summary")
-    
+
     async def generate_sample_prompt(self, random_row: bool = True) -> dict:
         """
         Generates sample prompt(s) using a single row from the CSV file.
         If random_row is True, a random row from the first batch is selected;
         otherwise, the first row is used.
-        
+
         Returns:
             dict: A mapping of mention column names to the generated prompt.
         """
@@ -256,7 +244,7 @@ class LionLinker:
 
         # Read the first chunk from the CSV file.
         try:
-            chunk_iter = pd.read_csv(self.input_csv, chunksize=self.batch_size)
+            chunk_iter = pd.read_csv(self.input_csv, chunksize=self.chunk_size)
             chunk = next(chunk_iter)
         except StopIteration:
             raise ValueError("Input CSV is empty or not accessible.")
@@ -293,7 +281,7 @@ class LionLinker:
 
             entity_mention = sample_row[col]
             # Fetch candidate entities for the mention.
-            candidates_dict = await self.api_client.fetch_multiple_entities([entity_mention])
+            candidates_dict = await self.retriever.fetch_multiple_entities([entity_mention])
             candidates = candidates_dict.get(entity_mention, [])
             prompt = self.prompt_generator.generate_prompt(
                 table=table_list,
@@ -308,14 +296,14 @@ class LionLinker:
             prompts[col] = prompt
 
         return prompts
-    
+
     async def send_prompt_sample(self, prompt_sample: dict) -> dict:
         """
         Sends each prompt in the provided prompt sample to the LLM and returns the responses.
 
         Args:
             prompt_sample (dict): A dictionary mapping mention column names to prompt texts.
-            
+
         Returns:
             dict: A dictionary mapping each mention column to a dictionary with keys:
                   'prompt', 'response', and 'extracted_identifier'.
@@ -325,10 +313,10 @@ class LionLinker:
             response = self.llm_interaction.chat(prompt)
             results[col] = {
                 "response": response.replace("\n", "").strip(),
-                "extracted_identifier": self.extract_identifier_from_response(response)
+                "extracted_identifier": self.extract_identifier_from_response(response),
             }
         return results
-    
+
     async def run(self):
         logging.info(f"Starting processing of {self.input_csv}...")
 
@@ -345,18 +333,36 @@ class LionLinker:
         actual_rows_processed = 0
 
         # Proceed with batch processing
-        with pd.read_csv(self.input_csv, chunksize=self.batch_size) as reader:
-            for chunk in reader:
+        with pd.read_csv(self.input_csv, chunksize=self.chunk_size) as reader:
+            for chunk_id, chunk in enumerate(reader):
                 batch_results = await self.process_chunk(chunk)
-                # Append results to CSV, ensuring proper handling of newlines
-                pd.DataFrame(batch_results).to_csv(
-                    self.output_csv,
-                    mode="a",
-                    header=False,
-                    index=False,
-                    quoting=1,
-                    escapechar="\\",
-                )
+                batch_results = pd.DataFrame(batch_results)
+
+                # Merge batch_results with the chunk
+                if "id_row" not in chunk.columns:
+                    chunk = chunk.reset_index().rename(columns={"index": "id_row"})
+                merged_chunk = chunk.merge(batch_results, on="id_row", how="left")
+                merged_chunk = merged_chunk.drop(columns=["id_row"])
+
+                if chunk_id == 0:
+                    # Write the header for the first chunk
+                    merged_chunk.to_csv(
+                        self.output_csv,
+                        mode="w",
+                        index=False,
+                        quoting=1,
+                        escapechar="\\",
+                    )
+                else:
+                    # Append results to CSV, ensuring proper handling of newlines
+                    merged_chunk.to_csv(
+                        self.output_csv,
+                        mode="a",
+                        header=False,
+                        index=False,
+                        quoting=1,
+                        escapechar="\\",
+                    )
 
                 # Update the progress bar with the actual number of rows processed
                 actual_rows_processed += len(chunk)

--- a/lion_linker/prompt/generator.py
+++ b/lion_linker/prompt/generator.py
@@ -44,7 +44,11 @@ class PromptGenerator:
                 "id": candidate["id"],
                 "name": candidate["name"],
                 "description": candidate["description"],
-                "types": [{"id": t["id"], "name": t["name"]} for t in candidate["types"]],
+                "types": [
+                    {"id": t["id"], "name": t["name"]}
+                    for t in candidate["types"]
+                    if t["name"] is not None
+                ],
             }
             optimized_candidates.append(optimized_candidate)
 

--- a/lion_linker/retrievers.py
+++ b/lion_linker/retrievers.py
@@ -1,0 +1,99 @@
+import asyncio
+
+import aiohttp
+
+
+class RetrieverClient:
+    def __init__(
+        self,
+        endpoint: str,
+        token: str = None,
+        parse_response_func=None,
+        max_retries=3,
+        backoff_factor=0.5,
+        num_candidates=10,
+    ):
+        self.endpoint = endpoint
+        self.token = token
+        self.parse_response_func = parse_response_func
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.num_candidates = num_candidates
+
+    async def fetch_entities(self, query, session):
+        raise NotImplementedError
+
+    async def fetch_multiple_entities(self, queries):
+        async with aiohttp.ClientSession() as session:
+            tasks = [self.fetch_entities(query, session) for query in queries]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            # Handle failed requests (e.g., those returning exceptions)
+            output = {}
+            for query, result in zip(queries, results):
+                if isinstance(result, Exception):
+                    output[query] = f"Error: {str(result)}"
+                else:
+                    output[query] = result
+            return output
+
+
+class LamapiClient(RetrieverClient):
+    def __init__(
+        self,
+        endpoint: str,
+        token: str = None,
+        parse_response_func=None,
+        max_retries=3,
+        backoff_factor=0.5,
+        num_candidates=10,
+        kg="wikidata",
+        cache: bool = False,
+    ):
+        super().__init__(
+            endpoint=endpoint,
+            token=token,
+            parse_response_func=parse_response_func,
+            max_retries=max_retries,
+            backoff_factor=backoff_factor,
+            num_candidates=num_candidates,
+        )
+        self.kg = kg
+        self.cache = cache
+
+    async def fetch_entities(self, query, session):
+        params = {
+            "name": query,
+            "limit": self.num_candidates,
+            "kg": self.kg,
+            "cache": str(self.cache),
+        }  # Added kg parameter to request params
+        if self.token:
+            params["token"] = self.token
+
+        retries = 0
+        while retries < self.max_retries:
+            try:
+                async with session.get(self.endpoint, params=params, ssl=False) as response:
+                    response.raise_for_status()
+                    response_json = await response.json()
+                    if self.parse_response_func:
+                        return self.parse_response_func(response_json)
+                    return response_json
+            except aiohttp.ClientResponseError as e:
+                if e.status in {502, 503, 504}:  # Server errors
+                    retries += 1
+                    wait_time = self.backoff_factor * (2**retries)  # Exponential backoff
+                    print(f"Error {e.status}, retrying in {wait_time:.2f} seconds...")
+                    await asyncio.sleep(wait_time)
+                else:
+                    print(f"ClientResponseError: {e}")
+                    raise
+            except aiohttp.ClientConnectionError as e:
+                print(f"ConnectionError: {e}")
+                raise
+            except Exception as e:
+                print(f"Unexpected error: {e}")
+                raise
+
+        raise Exception(f"Failed to fetch after {self.max_retries} retries")

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, patch
 
 from dotenv import load_dotenv
 
+from lion_linker import PROJECT_ROOT
 from lion_linker.lion_linker import LionLinker
+from lion_linker.retrievers import LamapiClient
 
 # Load environment variables from .env
 load_dotenv()
@@ -16,28 +18,33 @@ class TestLionLinker(unittest.TestCase):
     def setUpClass(cls):
         # Define required test parameters
         cls.input_csv = "tests/data/film.csv"  # Replace with a small, valid CSV path for testing
-        cls.prompt_file = "prompt_template.txt"  # Replace with a valid prompt file for testing
+        cls.prompt_file_path = os.path.join(
+            PROJECT_ROOT, "prompt", "prompt_template.txt"
+        )  # Replace with a valid prompt file for testing
         cls.model_name = "llama3.2:1b"
         cls.output_csv = "output_test.csv"
-        cls.batch_size = 5
-        cls.api_limit = 10
-        cls.api_url = os.getenv("API_URL")
-        cls.api_token = os.getenv("API_TOKEN")
+        cls.chunk_size = 5
+        cls.num_candidates = 5
+        cls.retriever_endpoint = os.getenv("RETRIEVER_ENDPOINT")
+        cls.retriever_token = os.getenv("RETRIEVER_TOKEN")
         cls.mention_columns = ["title"]
         cls.gt_columns = []
+        cls.retriever = LamapiClient(
+            endpoint=cls.retriever_endpoint,
+            token=cls.retriever_token,
+            num_candidates=cls.num_candidates,
+        )
 
     def test_initialization(self):
         """Test LionLinker initialization with required parameters."""
         lion_linker = LionLinker(
             input_csv=self.input_csv,
-            prompt_file=self.prompt_file,
+            prompt_file_path=self.prompt_file_path,
             model_name=self.model_name,
-            api_url=self.api_url,
-            api_token=self.api_token,
+            retriever=self.retriever,
             output_csv=self.output_csv,
-            batch_size=self.batch_size,
+            chunk_size=self.chunk_size,
             mention_columns=self.mention_columns,
-            api_limit=self.api_limit,
             gt_columns=self.gt_columns,
         )
         self.assertIsInstance(
@@ -45,22 +52,26 @@ class TestLionLinker(unittest.TestCase):
         )
 
     def test_env_loading(self):
-        """Test that environment variables for API URL and token are loaded correctly."""
-        self.assertIsNotNone(self.api_url, "API_URL should not be None")
-        self.assertIsNotNone(self.api_token, "API_TOKEN should not be None")
+        """Test that environment variables for retriever
+        endpoint and token are loaded correctly."""
+        self.assertIsNotNone(self.retriever.endpoint, "RETRIEVER_URL should not be None")
+        self.assertIsNotNone(self.retriever.token, "RETRIEVER_TOKEN should not be None")
 
     def test_run_method(self):
         """Test the run method to ensure it can be called without errors."""
+        retriever = LamapiClient(
+            endpoint=self.retriever_endpoint,
+            token=self.retriever_token,
+            num_candidates=self.num_candidates,
+        )
         lion_linker = LionLinker(
             input_csv=self.input_csv,
-            prompt_file=self.prompt_file,
+            prompt_file_path=self.prompt_file_path,
             model_name=self.model_name,
-            api_url=self.api_url,
-            api_token=self.api_token,
+            retriever=retriever,
             output_csv=self.output_csv,
-            batch_size=self.batch_size,
+            chunk_size=self.chunk_size,
             mention_columns=self.mention_columns,
-            api_limit=self.api_limit,
             gt_columns=self.gt_columns,
         )
 


### PR DESCRIPTION
In this refactor we have:
* Decoupled the retrievers and defined a `retrievers.py` module, where all the retrievers will be placed. A superclass is defined and the `LamapiClient` is extended from that superclass. In the future more retrievers will be available (wikidata for example)
* Moved all retriever-related parameters to their class
* Some parameters' naming has been changed, for example
    * `batch_size` --> `chunk_size`
    * `api_url` --> `retriever_url`
* Enriched the input csv file by copying the output file and adding as much columns as there are mention to annotate per row, adding also the LLM answer for every mention